### PR TITLE
feat(installer): update Helm charts to make ingress-nginx more configurable

### DIFF
--- a/charts/direktiv/Chart.yaml
+++ b/charts/direktiv/Chart.yaml
@@ -25,9 +25,9 @@ version: 0.1.0
 appVersion: "v0.5.10"
 
 dependencies:
-    - name: prometheus
-      repository: "https://prometheus-community.github.io/helm-charts"
-      version: "14.7.1"
-    - name: ingress-nginx
-      repository: "https://kubernetes.github.io/ingress-nginx"
-      version: "4.0.13"
+    # - name: prometheus
+    #   repository: "https://prometheus-community.github.io/helm-charts"
+    #   version: "14.7.1"
+    # - name: ingress-nginx
+    #   repository: "https://kubernetes.github.io/ingress-nginx"
+    #   version: "4.0.13"

--- a/charts/direktiv/Chart.yaml
+++ b/charts/direktiv/Chart.yaml
@@ -25,9 +25,10 @@ version: 0.1.0
 appVersion: "v0.5.10"
 
 dependencies:
-    # - name: prometheus
-    #   repository: "https://prometheus-community.github.io/helm-charts"
-    #   version: "14.7.1"
-    # - name: ingress-nginx
-    #   repository: "https://kubernetes.github.io/ingress-nginx"
-    #   version: "4.0.13"
+  - name: prometheus
+    repository: "https://prometheus-community.github.io/helm-charts"
+    version: "14.7.1"
+  - name: ingress-nginx
+    repository: "https://kubernetes.github.io/ingress-nginx"
+    version: "4.0.13"
+    condition: ingress-nginx.install

--- a/charts/direktiv/README.md
+++ b/charts/direktiv/README.md
@@ -81,6 +81,7 @@ $ helm install direktiv direktiv/direktiv
 | ingress.certificate | string | `"none"` | TLS secret |
 | ingress.class | string | `"nginx"` | ingress class |
 | ingress.host | string | `""` | host for external services, only required for TLS |
+| ingress.additionalAnnotations | object | `{}` | Additional Annontations for ingress |
 | logging | string | `"json"` | json or console logger |
 | networkPolicies.db | string | `"0.0.0.0/0"` | CIDR for database, excempt from policies |
 | networkPolicies.enabled | bool | `false` | adds network policies |

--- a/charts/direktiv/templates/ingress-api.yaml
+++ b/charts/direktiv/templates/ingress-api.yaml
@@ -9,6 +9,9 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "{{ .Values.timeout }}"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "{{ .Values.timeout }}"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ .Values.timeout }}"
+    {{- range $key, $value := .Values.ingress.additionalAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
     {{- if ne .Values.ingress.certificate "none" }}
     ingress.kubernetes.io/force-ssl-redirect: "true"
     {{- end }}

--- a/charts/direktiv/templates/ingress-ui.yaml
+++ b/charts/direktiv/templates/ingress-ui.yaml
@@ -9,6 +9,9 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "{{ .Values.timeout }}"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "{{ .Values.timeout }}"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ .Values.timeout }}"
+    {{- range $key, $value := .Values.ingress.additionalAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
     {{- if ne .Values.ingress.certificate "none" }}
     ingress.kubernetes.io/force-ssl-redirect: "true"
     {{- end }}

--- a/charts/direktiv/values.yaml
+++ b/charts/direktiv/values.yaml
@@ -294,6 +294,7 @@ apikey: none
 
 # -- nginx ingress controller configuration
 ingress-nginx:
+  install: true
   controller:
     podAnnotations:
       linkerd.io/inject: disabled

--- a/charts/direktiv/values.yaml
+++ b/charts/direktiv/values.yaml
@@ -96,7 +96,9 @@ ingress:
   certificate: none
   # -- ingress class
   class: "nginx"
-
+  # -- Additional Annotations
+  additionalAnnotations: {}
+    
 database:
   # -- database host
   host: "postgres-postgresql-ha-pgpool.postgres"


### PR DESCRIPTION
This PR is to update the direktiv chart to allow ingress-nginx to be more configurable. 

There are two changes made.  

One is whether or not you install the ingress-nginx or not eg you might already have one setup in the cluster and this will run into conflicts

The second is to add your own annotations. eg you might run external dns or cert-manager and require extra annotations to allow you to use it how you want.

This was done in a way that will make no breaking changes, and will produce the same manifest files as the defaults are set to install: true, and additionalAnnotations: {}

## Related Issues
Resolves Issue: #394
Fixes #394

## How to test
- update charts/direktiv/values.yaml line 296 for whether to install ingress-nginx or not
- update charts/direktiv/values.yaml line 100 for whether to install additionalAnnotations or not

helm dependency update charts/direktiv/
helm install --debug --dry-run charts/direktiv --generate-name
