### PR TITLE
Feat/397/update prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# direktiv-charts
-Helm charts for Direktiv
+[![Slack](https://img.shields.io/badge/Slack-Join%20Direktiv-4a154b?style=flat&logo=slack)](https://join.slack.com/t/direktiv-io/shared_invite/zt-zf7gmfaa-rYxxBiB9RpuRGMuIasNO~g)
+
+This repository contains the Helm charts for Direktiv. To view the readme's for the charts click the links below:
+
+* [direktiv](charts/direktiv/README.md)
+* [knative](charts/knative/README.md)
+* [pgo](charts/pgo/README.md)
+
+# Code of Conduct
+
+We have adopted the [Contributor Covenant](https://github.com/direktiv/.github/blob/master/CODE_OF_CONDUCT.md) code of conduct.
+
+# Contributing
+
+Any feedback and contributions are welcome. Read our [contributing guidelines](https://github.com/direktiv/.github/blob/master/CONTRIBUTING.md) for details.
+# License
+
+Distributed under the Apache 2.0 License. See `LICENSE` for more information.
+
+# See Also
+
+* The [direktiv.io](https://direktiv.io/) website.
+* The direktiv [documentation](https://docs.direktiv.io/).
+* The direktiv [blog](https://blog.direktiv.io/).
+* The [Godoc](https://godoc.org/github.com/direktiv/direktiv) library documentation.

--- a/charts/direktiv/Chart.yaml
+++ b/charts/direktiv/Chart.yaml
@@ -28,6 +28,7 @@ dependencies:
   - name: prometheus
     repository: "https://prometheus-community.github.io/helm-charts"
     version: "14.7.1"
+    condition: prometheus.install
   - name: ingress-nginx
     repository: "https://kubernetes.github.io/ingress-nginx"
     version: "4.0.13"

--- a/charts/direktiv/templates/flow/flow-cm-config.yaml
+++ b/charts/direktiv/templates/flow/flow-cm-config.yaml
@@ -10,7 +10,11 @@ data:
       functions-service: {{ include "direktiv.fullname" . }}-functions.{{ .Release.Namespace }}
       functions-timeout: {{ .Values.timeout }}
       flow-service: {{ include "direktiv.fullname" . }}-flow.{{ .Release.Namespace }}
+      {{- if .Values.prometheus.install }}
       prometheus-backend: {{ include "direktiv.fullname" . }}-prometheus-server
+      {{- else }}
+      prometheus-backend: {{ .Values.prometheus.backendName }}
+      {{- end }}
       {{- if .Values.opentelemetry.address }}
       {{- if .Values.opentelemetry.enabled }}
       opentelemetry-backend: {{ .Values.opentelemetry.address }}

--- a/charts/direktiv/values.yaml
+++ b/charts/direktiv/values.yaml
@@ -198,7 +198,8 @@ ui:
   affinity: {}
 
 prometheus:
-  install: true
+  install: false
+  backendName: "prom-backend-server" # required if install = false
   global:
     scrape_interval: 1m
     evaluation_interval: 1m

--- a/charts/direktiv/values.yaml
+++ b/charts/direktiv/values.yaml
@@ -198,6 +198,7 @@ ui:
   affinity: {}
 
 prometheus:
+  install: true
   global:
     scrape_interval: 1m
     evaluation_interval: 1m


### PR DESCRIPTION
## Description

Made Prometheus dependency an optional toggle with a boolean flag in values.yaml

## Purpose

- [ ] Allow users to choose between their own Prometheus or install as part of Direktiv

## How was this tested? (if applicable)

```
helm dependency update charts/direktiv/
helm install --debug --dry-run charts/direktiv --generate-name
```
Output confirms when values.prometheus.install is set to false, the prometheus resources aren't installed


Closes issue [#397](https://github.com/direktiv/direktiv/issues/397) and [#398](https://github.com/direktiv/direktiv/issues/398)