### PR TITLE
Prometheus now installs by default

### DIFF
--- a/charts/direktiv/values.yaml
+++ b/charts/direktiv/values.yaml
@@ -198,7 +198,7 @@ ui:
   affinity: {}
 
 prometheus:
-  install: false
+  install: true
   backendName: "prom-backend-server" # required if install = false
   global:
     scrape_interval: 1m


### PR DESCRIPTION
Signed-off-by: jalfvort <jon.alfaro@direktiv.io>

## Description

It makes sense for Prometheus to install by default, as a user may not have one readily configured.

## Purpose

- [ ] Bug fix
- [ ] New feature
- [X] Other