### PR TITLE
sidecar and init-pod naming like images

### DIFF
--- a/charts/direktiv/Chart.lock
+++ b/charts/direktiv/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
   version: 4.0.13
-digest: sha256:b2b7921d2ff029bb12656ec5d1574537078e56bf8634a0198d433aed29fc074f
-generated: "2021-12-22T13:06:38.442828211+10:00"
+digest: sha256:786f5c046eaaa8bd87b81f6ad7912955746f7fcd9a5de89d8d4047bd21d2ad5a
+generated: "2022-01-02T08:17:24.868565092+10:00"

--- a/charts/direktiv/templates/functions/functions-cm-config.yaml
+++ b/charts/direktiv/templates/functions/functions-cm-config.yaml
@@ -38,10 +38,10 @@ data:
       namespace: {{ .Values.functions.namespace }}
 
       # pod sidecar name
-      sidecar: {{ .Values.functions.sidecar }}
+      sidecar: {{ .Values.registry }}/{{ .Values.functions.sidecar }}:{{ .Values.functions.tag | default .Chart.AppVersion }}
 
       # init pod name
-      init-pod: {{ .Values.functions.initPodImage }}
+      init-pod: {{ .Values.registry }}/{{ .Values.functions.initPodImage }}:{{ .Values.functions.tag | default .Chart.AppVersion }}
 
       # max number of revisions to keep per namespace or global
       keep-revisions: 3


### PR DESCRIPTION
Signed-off-by: Jens Gerke <jens.gerke@direktiv.io>

this naming change make it easier to versioning sidecar and initpod