### PR TITLE
Volumes added to ui deployment for nginx

### DIFF
--- a/charts/direktiv/templates/ui/ui-deployment.yaml
+++ b/charts/direktiv/templates/ui/ui-deployment.yaml
@@ -40,6 +40,11 @@ spec:
 {{ toYaml .Values.ui.extraContainers | indent 8 }}
 {{- end }}
         - name: ui
+          volumeMounts:
+          - mountPath: /var/run
+            name: tmpfs-nginx
+          - mountPath: /var/cache/nginx
+            name: tmpfs-nginx-cache
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
@@ -62,6 +67,10 @@ spec:
               containerPort: 8080
               protocol: TCP
       volumes:
+      - name: tmpfs-nginx
+        emptyDir: {}
+      - name: tmpfs-nginx-cache
+        emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Signed-off-by: jalfvort <jon.alfaro@direktiv.io>

## Description

We are moving from our reactjs-embeded server to nginx on release 0.7. Ngnix requires two paths to write temp files, however the containers pod fs is read-only. Two tmpfs volumes are added in this PR to give Nginx paths to write its temp files.

## Related Issue
https://github.com/direktiv/direktiv/issues/619

## Related Pull Requests
https://github.com/direktiv/direktiv-ui-ee/pull/16
https://github.com/direktiv/direktiv-ui/pull/323
https://github.com/direktiv/direktiv-charts/pull/24