### PR TITLE
add helm resource (cpu + memory) vars to chart

### DIFF
--- a/charts/direktiv/templates/api/api-deployment.yaml
+++ b/charts/direktiv/templates/api/api-deployment.yaml
@@ -52,9 +52,9 @@ spec:
             allowPrivilegeEscalation: false
           resources:
             requests:
-              memory: "128Mi"
+              memory: {{ .Values.api.resources.requests.memory }}
             limits:
-              memory: "1048Mi"
+              memory: {{ .Values.api.resources.limits.memory }}
           image: "{{ .Values.registry }}/{{ .Values.api.image }}:{{ .Values.api.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.pullPolicy }}
           command: ["/bin/direktiv", "-c", "/config/api-config.yaml"]

--- a/charts/direktiv/templates/flow/flow-deployment.yaml
+++ b/charts/direktiv/templates/flow/flow-deployment.yaml
@@ -129,9 +129,9 @@ spec:
             runAsGroup: 65532
           resources:
             requests:
-              memory: "128Mi"
+              memory: {{ .Values.flow.containers.secrets.resources.requests.memory }}
             limits:
-              memory: "512Mi"
+              memory: {{ .Values.flow.containers.secrets.resources.limits.memory }}
           image: "{{ .Values.registry }}/{{ .Values.secrets.image }}:{{ .Values.secrets.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.pullPolicy }}
           volumeMounts:

--- a/charts/direktiv/templates/functions/functions-deployment.yaml
+++ b/charts/direktiv/templates/functions/functions-deployment.yaml
@@ -73,9 +73,9 @@ spec:
             allowPrivilegeEscalation: false
           resources:
             requests:
-              memory: "128Mi"
+              memory: {{ .Values.functions.containers.functions-controller.resources.requests.memory }}
             limits:
-              memory: "1024Mi"
+              memory: {{ .Values.functions.containers.functions-controller.resources.limits.memory }}
           image: "{{ .Values.registry }}/{{ .Values.functions.image }}:{{ .Values.functions.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.pullPolicy }}
           ports:

--- a/charts/direktiv/templates/ui/ui-deployment.yaml
+++ b/charts/direktiv/templates/ui/ui-deployment.yaml
@@ -54,9 +54,9 @@ spec:
             allowPrivilegeEscalation: false
           resources:
             requests:
-              memory: "128Mi"
+              memory: {{ .Values.ui.containers.ui.resources.requests.memory }}
             limits:
-              memory: "2048Mi"
+              memory: {{ .Values.ui.containers.ui.resources.limits.memory }}
           image: "{{ .Values.registry }}/{{ .Values.ui.image }}:{{ .Values.ui.tag | default .Chart.AppVersion }}"
           env:
           - name: SERVE_PORT

--- a/charts/direktiv/values.yaml
+++ b/charts/direktiv/values.yaml
@@ -79,6 +79,12 @@ api:
     #     name: service-template
   affinity: {}
 
+  resources:
+    requests:
+      memory: "128Mi"
+    limits:
+      memory: "1048Mi"
+
 networkPolicies:
   # -- adds network policies
   enabled: false
@@ -172,6 +178,14 @@ flow:
     #         values:
     #         - direktiv
     #     topologyKey: kubernetes.io/hostname
+  
+  containers:
+    secrets:
+      resources:
+        requests:
+          memory: "128Mi"
+        limits:
+          memory: "512Mi"
 
 
 nodeSelector: {}
@@ -204,6 +218,13 @@ ui:
   certificate: none
   extraContainers: []
   affinity: {}
+  containers:
+    ui:
+      resources:
+        requests:
+          memory: "128Mi"
+        limits:
+          memory: "2048Mi"
   
 prometheus:
   install: true
@@ -313,6 +334,14 @@ functions:
     #     requests:
     #       memory: "2Gi"
     #       cpu:    "1"
+  
+  containers:
+    functions-controller:
+      resources:
+        requests:
+          memory: "128Mi"
+        limits:
+          memory: "1024Mi"
 
 # -- enabled api key for API authentication with the `direktiv-token` header, key set in http-snippet in `ingress-nginx` none
 apikey: none

--- a/charts/knative-instance/templates/contour.yaml
+++ b/charts/knative-instance/templates/contour.yaml
@@ -7090,11 +7090,11 @@ spec:
         name: shutdown-manager
         resources:
           limits:
-            cpu: 400m
-            memory: 400Mi
+            cpu: {{ .Values.envoy.containers.shutdown-manager.resources.limits.cpu }}
+            memory: {{ .Values.envoy.containers.shutdown-manager.resources.limits.memory }}
           requests:
-            cpu: 40m
-            memory: 40Mi
+            cpu: {{ .Values.envoy.containers.shutdown-manager.resources.requests.cpu }}
+            memory: {{ .Values.envoy.containers.shutdown-manager.resources.requests.memory }}
         volumeMounts:
         - mountPath: /admin
           name: envoy-admin

--- a/charts/knative-instance/values.yaml
+++ b/charts/knative-instance/values.yaml
@@ -12,4 +12,13 @@ certificate: ""
 # -- Repositories which skip digest resolution
 skip-digest: kind.local,ko.local,dev.local,localhost:5000,localhost:31212
 
-
+envoy:
+  containers:
+    shutdown-manager:
+      resources:
+        requests:
+          cpu: "40m"
+          memory: "40Mi"
+        limits:
+          cpu: "400m"
+          memory: "400Mi"

--- a/charts/knative/templates/contour.yaml
+++ b/charts/knative/templates/contour.yaml
@@ -5255,11 +5255,11 @@ spec:
         name: shutdown-manager
         resources:
           limits:
-            cpu: 400m
-            memory: 400Mi
+            cpu: {{ .Values.envoy.containers.shutdown-manager.resources.limits.cpu }}
+            memory: {{ .Values.envoy.containers.shutdown-manager.resources.limits.memory }}
           requests:
-            cpu: 40m
-            memory: 40Mi
+            cpu: {{ .Values.envoy.containers.shutdown-manager.resources.requests.cpu }}
+            memory: {{ .Values.envoy.containers.shutdown-manager.resources.requests.memory }}
         volumeMounts:
         - mountPath: /admin
           name: envoy-admin
@@ -5306,11 +5306,11 @@ spec:
           periodSeconds: 4
         resources:
           limits:
-            cpu: 500m
-            memory: 500Mi
+            cpu: {{ .Values.envoy.containers.envoy.resources.limits.cpu }}
+            memory: {{ .Values.envoy.containers.envoy.resources.limits.memory }}
           requests:
-            cpu: 200m
-            memory: 200Mi
+            cpu: {{ .Values.envoy.containers.envoy.resources.requests.cpu }}
+            memory: {{ .Values.envoy.containers.envoy.resources.limits.memory }}
         volumeMounts:
         - mountPath: /config
           name: envoy-config
@@ -5898,11 +5898,11 @@ spec:
         name: shutdown-manager
         resources:
           limits:
-            cpu: 400m
-            memory: 400Mi
+            cpu: {{ .Values.envoy.containers.shutdown-manager.resources.limits.cpu }}
+            memory: {{ .Values.envoy.containers.shutdown-manager.resources.limits.memory }}
           requests:
-            cpu: 40m
-            memory: 40Mi
+            cpu: {{ .Values.envoy.containers.shutdown-manager.resources.requests.cpu }}
+            memory: {{ .Values.envoy.containers.shutdown-manager.resources.requests.memory }}
         volumeMounts:
         - mountPath: /admin
           name: envoy-admin
@@ -5949,11 +5949,11 @@ spec:
           periodSeconds: 4
         resources:
           limits:
-            cpu: 500m
-            memory: 500Mi
+            cpu: {{ .Values.envoy.containers.envoy.resources.limits.cpu }}
+            memory: {{ .Values.envoy.containers.envoy.resources.limits.memory }}
           requests:
-            cpu: 200m
-            memory: 200Mi
+            cpu: {{ .Values.envoy.containers.envoy.resources.requests.cpu }}
+            memory: {{ .Values.envoy.containers.envoy.resources.requests.memory }}
         volumeMounts:
         - mountPath: /config
           name: envoy-config

--- a/charts/knative/templates/net-contour.yaml
+++ b/charts/knative/templates/net-contour.yaml
@@ -116,11 +116,11 @@ spec:
           name: profiling
         resources:
           limits:
-            cpu: 400m
-            memory: 400Mi
+            cpu: {{ .Values.net-contour-controller.containers.controller.resources.limits.cpu }}
+            memory: {{ .Values.net-contour-controller.containers.controller.resources.limits.memory }}
           requests:
-            cpu: 40m
-            memory: 40Mi
+            cpu: {{ .Values.net-contour-controller.containers.controller.resources.requests.cpu }}
+            memory: {{ .Values.net-contour-controller.containers.controller.resources.requests.memory }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/charts/knative/templates/serving-core.yaml
+++ b/charts/knative/templates/serving-core.yaml
@@ -1221,11 +1221,11 @@ spec:
           periodSeconds: 5
         resources:
           limits:
-            cpu: "1"
-            memory: 600Mi
+            cpu: {{ .Values.activator.containers.activator.resources.limits.cpu }}
+            memory: {{ .Values.activator.containers.activator.resources.limits.memory }}
           requests:
-            cpu: 300m
-            memory: 60Mi
+            cpu: {{ .Values.activator.containers.activator.resources.requests.cpu }}
+            memory: {{ .Values.activator.containers.activator.resources.requests.memory }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -1356,11 +1356,11 @@ spec:
             port: 8080
         resources:
           limits:
-            cpu: "1"
-            memory: 1000Mi
+            cpu: {{ .Values.activator.containers.autoscaler.resources.limits.cpu }}
+            memory: {{ .Values.activator.containers.autoscaler.resources.limits.memory }}
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: {{ .Values.activator.containers.autoscaler.resources.requests.cpu }}
+            memory: {{ .Values.activator.containers.autoscaler.resources.requests.memory }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -1469,11 +1469,11 @@ spec:
           name: profiling
         resources:
           limits:
-            cpu: "1"
-            memory: 1000Mi
+            cpu: {{ .Values.activator.containers.controller.resources.limits.cpu }}
+            memory: {{ .Values.activator.containers.controller.resources.limits.memory }}
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: {{ .Values.activator.containers.controller.resources.requests.cpu }}
+            memory: {{ .Values.activator.containers.controller.resources.requests.memory }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -1574,11 +1574,11 @@ spec:
           name: profiling
         resources:
           limits:
-            cpu: 300m
-            memory: 400Mi
+            cpu: {{ .Values.activator.containers.domain-mapping.resources.limits.cpu }}
+            memory: {{ .Values.activator.containers.domain-mapping.resources.limits.memory }}
           requests:
-            cpu: 30m
-            memory: 40Mi
+            cpu: {{ .Values.activator.containers.domain-mapping.resources.requests.cpu }}
+            memory: {{ .Values.activator.containers.domain-mapping.resources.requests.memory }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -1675,11 +1675,11 @@ spec:
           periodSeconds: 1
         resources:
           limits:
-            cpu: 500m
-            memory: 500Mi
+            cpu: {{ .Values.activator.containers.domainmapping-webhook.resources.limits.cpu }}
+            memory: {{ .Values.activator.containers.domainmapping-webhook.resources.limits.memory }}
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: {{ .Values.activator.containers.domainmapping-webhook.resources.requests.cpu }}
+            memory: {{ .Values.activator.containers.domainmapping-webhook.resources.requests.memory }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -1859,11 +1859,11 @@ spec:
           periodSeconds: 1
         resources:
           limits:
-            cpu: 500m
-            memory: 500Mi
+            cpu: {{ .Values.activator.containers.webhook.resources.limits.cpu }}
+            memory: {{ .Values.activator.containers.webhook.resources.limits.memory }}
           requests:
-            cpu: 100m
-            memory: 100Mi
+            cpu: {{ .Values.activator.containers.webhook.resources.requests.cpu }}
+            memory: {{ .Values.activator.containers.webhook.resources.requests.memory }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/charts/knative/values.yaml
+++ b/charts/knative/values.yaml
@@ -29,3 +29,82 @@ deployment:
 controller:
   # -- CA certifcate for self-signed certificate registries
   ca: none
+
+envoy:
+  containers:
+    shutdown-manager:
+      resources:
+        requests:
+          cpu: "40m"
+          memory: "40Mi"
+        limits:
+          cpu: "400m"
+          memory: "400Mi"
+    envoy:
+      resources:
+        requests:
+          cpu: "200m"
+          memory: "200Mi"
+        limits:
+          cpu: "500m"
+          memory: "500Mi"
+net-contour-controller:
+  containers:
+    controller:
+      resources:
+        requests:
+          cpu: "40m"
+          memory: "400Mi"
+        limits:
+          cpu: "400m"
+          memory: "400Mi"
+activator:
+  containers:
+    activator:
+      resources:
+        requests:
+          cpu: "300m"
+          memory: "60Mi"
+        limits:
+          cpu: "1"
+          memory: "600Mi"
+    autoscaler:
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "100Mi"
+        limits:
+          cpu: "1"
+          memory: "1000Mi"
+    controller:
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "100Mi"
+        limits:
+          cpu: "1"
+          memory: "1000Mi"
+    domain-mapping:
+      resources:
+        requests:
+          cpu: "30m"
+          memory: "40Mi"
+        limits:
+          cpu: "300m"
+          memory: "400Mi"
+    domainmapping-webhook:
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "100Mi"
+        limits:
+          cpu: "500m"
+          memory: "500Mi"
+    webhook:
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "100Mi"
+        limits:
+          cpu: "500m"
+          memory: "500Mi"


### PR DESCRIPTION
## Description

This PR:

- Makes CPU and Memory requests and limits configurable for the entire chart

Closes #37 

## Purpose

- [ ] Bug fix
- [x] New feature
- [ ] Other