### PR TITLE
fix: removes redundant codes in direktiv chart

### DIFF
--- a/charts/direktiv/templates/flow/flow-deployment.yaml
+++ b/charts/direktiv/templates/flow/flow-deployment.yaml
@@ -119,11 +119,10 @@ spec:
           - name: DIREKTIV_FUNCTIONS_TIMEOUT
             value: {{ .Values.requestTimeout | quote }}
           - name: DIREKTIV_PROMETHEUS_BACKEND
-            value: {{ .Values.prometheus.backendName | quote }}
           {{- if .Values.prometheus.install }}
             value: {{ include "direktiv.fullname" . }}-prometheus-server.{{ .Release.Namespace }}
           {{- else }}
-            value: {{ .Values.prometheus.backendName }}
+            value: {{ .Values.prometheus.backendName | quote }}
           {{- end }}
           - name: DIREKTIV_OPEN_TELEMETRY_BACKEND
             value: {{ include "direktiv.opentelemetry-backend" . }}


### PR DESCRIPTION
## Description
Fixes #43

Removes redundant codes.
The former value will be overwritten by the latter one, it has no effect on the result manifest.

## Purpose

- [ ] Bug fix
- [ ] New feature
- [x] Other

## How was this tested? (if applicable)
`helm template .` works as before

## Test Platform Details (if applicable)

**Operating system:** OSX/Windows 10/Ubuntu 20.04/etc.

**CLI version:**

**Hypervisors/Platforms (if applicable):** qemu/hyper-v/google cloud platform/vmware workstation/etc

**Kernel version (if applicable):**

## Checklist

- [ ] Code is commented
- [ ] Unit test coverage encompasses new code
- [ ] Existing unit tests pass with these changes
- [ ] PR is signed
